### PR TITLE
Optional read hitmapbox

### DIFF
--- a/packages/regl-worldview/package.json
+++ b/packages/regl-worldview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl-worldview",
-  "version": "0.3.1-beta1.3.7",
+  "version": "0.3.1-beta1.3.7.2",
   "description": "A reusable component for rendering 2D and 3D views using regl",
   "license": "Apache-2.0",
   "repository": "cruise-automation/webviz/tree/master/packages/regl-worldview",

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -47,6 +47,8 @@ export type BaseProps = {|
   children?: React.Node,
   style: { [styleAttribute: string]: number | string },
 
+  readHitmapBoxOnDrag?: boolean,
+  disableCameraControls?: boolean,
   pointerLockDisabled?: boolean,
   cameraState?: $Shape<CameraState>,
   onCameraStateChange?: (CameraState) => void,
@@ -186,6 +188,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
 
   _onMouseMove = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
     const { _dragStartPos } = this;
+    const { readHitmapBoxOnDrag } = this.props;
     if (!_dragStartPos) {
       this._onMouseInteraction(e, "onMouseMove");
       return;
@@ -196,7 +199,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     const deltaY = clientY - _dragStartPos.y;
     const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
 
-    if (distance < DEFAULT_MOUSE_CLICK_RADIUS) {
+    if (distance < DEFAULT_MOUSE_CLICK_RADIUS || !readHitmapBoxOnDrag) {
       this._onMouseInteraction(e, "onMouseMove");
       return;
     }
@@ -206,6 +209,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
 
   _onMouseUp = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
     const { _dragStartPos } = this;
+    const { readHitmapBoxOnDrag } = this.props;
     if (!_dragStartPos) {
       this._onMouseInteraction(e, "onMouseUp");
       return;
@@ -223,7 +227,13 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       return;
     }
 
-    this._onMouseDragInteraction(e, "onMouseUp");
+    if (readHitmapBoxOnDrag) {
+      this._onMouseDragInteraction(e, "onMouseUp");
+      this._dragStartPos = null;
+      return;
+    }
+
+    this._onMouseInteraction(e, "onMouseUp");
     this._dragStartPos = null;
   };
 

--- a/packages/regl-worldview/src/Worldview.js
+++ b/packages/regl-worldview/src/Worldview.js
@@ -70,9 +70,10 @@ function handleWorldviewMouseInteraction(
   objects: MouseEventObject[],
   ray: Ray,
   e: SyntheticMouseEvent<HTMLCanvasElement>,
-  handler: MouseHandler
+  handler: MouseHandler,
+  hitboxObjects: MouseEventObject[]
 ) {
-  const args = { ray, objects };
+  const args = { ray, objects, hitboxObjects };
 
   try {
     handler(e, args);
@@ -204,7 +205,9 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
       return;
     }
 
-    this._onMouseDragInteraction(e, "onMouseMove");
+    this._onMouseInteraction(e, "onMouseMove", {
+      readHitmapBox: true,
+    });
   };
 
   _onMouseUp = (e: SyntheticMouseEvent<HTMLCanvasElement>) => {
@@ -228,7 +231,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     }
 
     if (readHitmapBoxOnDrag) {
-      this._onMouseDragInteraction(e, "onMouseUp");
+      this._onMouseInteraction(e, "onMouseUp", { readHitmapBox: true });
       this._dragStartPos = null;
       return;
     }
@@ -237,72 +240,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     this._dragStartPos = null;
   };
 
-  // read hitmap within a bounding box for drag interactions
-  _onMouseDragInteraction = (e: SyntheticMouseEvent<HTMLCanvasElement>, mouseEventName: MouseEventEnum) => {
-    const { _dragStartPos } = this;
-    if (!_dragStartPos) {
-      return;
-    }
-
-    const { clientX, clientY } = e;
-    const { clientWidth, clientHeight } = e.target;
-    const boundingClientRect = e.target.getBoundingClientRect();
-    const { width, height, right, bottom } = boundingClientRect;
-
-    // convert to normalized coordinates in the canvas
-    const normalizedX = clamp(((clientX - (right - width)) / width) * 2 - 1, -1, 1);
-    const normalizedY = clamp(-(((clientY - (bottom - height)) / height) * 2) + 1, -1, 1);
-    const normalizedDragStartX = clamp(((_dragStartPos.x - (right - width)) / width) * 2 - 1, -1, 1);
-    const normalizedDragStartY = clamp(-(((_dragStartPos.y - (bottom - height)) / height) * 2) + 1, -1, 1);
-
-    // use normalized coordinates to calculate offset position in the canvas
-    const offsetX = Math.floor(((normalizedX + 1) * clientWidth) / 2);
-    const offsetY = Math.floor(((-normalizedY + 1) * clientHeight) / 2);
-    const dragStartOffsetX = Math.floor(((normalizedDragStartX + 1) * clientWidth) / 2);
-    const dragStartOffsetY = Math.floor(((-normalizedDragStartY + 1) * clientHeight) / 2);
-
-    const deltaX = offsetX - dragStartOffsetX;
-    const deltaY = offsetY - dragStartOffsetY;
-
-    const { worldviewContext } = this.state;
-    const worldviewHandler = this.props[mouseEventName];
-
-    if (!(e.target instanceof window.HTMLElement) || e.button !== 0) {
-      return;
-    }
-
-    const canvasX = offsetX;
-    const canvasY = offsetY;
-    const ray = worldviewContext.raycast(canvasX, canvasY);
-    if (!ray) {
-      return;
-    }
-    const x = deltaX > 0 ? canvasX - deltaX : canvasX;
-    const y = deltaY > 0 ? canvasY : canvasY - deltaY;
-
-    // reading hitmap is async so we need to persist the event to use later in the event handler
-    (e: any).persist();
-    worldviewContext
-      .readHitmapBox(x, y, Math.abs(deltaX), Math.abs(deltaY))
-      .then((mouseEventsWithCommands) => {
-        const mouseEventsByCommand: Map<Command, Array<MouseEventObject>> = aggregate(mouseEventsWithCommands);
-        for (const [command, mouseEvents] of mouseEventsByCommand.entries()) {
-          command.handleMouseEvent(mouseEvents, ray, e, mouseEventName);
-          if (e.isPropagationStopped()) {
-            break;
-          }
-        }
-        if (worldviewHandler && !e.isPropagationStopped()) {
-          const mouseEvents = mouseEventsWithCommands.map(([mouseEventObject]) => mouseEventObject);
-          handleWorldviewMouseInteraction(mouseEvents, ray, e, worldviewHandler);
-        }
-      })
-      .catch((e) => {
-        console.error(e);
-      });
-  };
-
-  _onMouseInteraction = (e: SyntheticMouseEvent<HTMLCanvasElement>, mouseEventName: MouseEventEnum) => {
+  _onMouseInteraction = (e: SyntheticMouseEvent<HTMLCanvasElement>, mouseEventName: MouseEventEnum, options = {}) => {
     const { worldviewContext } = this.state;
     const worldviewHandler = this.props[mouseEventName];
 
@@ -323,9 +261,27 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     const offsetX = Math.floor(((normalizedX + 1) * clientWidth) / 2);
     const offsetY = Math.floor(((-normalizedY + 1) * clientHeight) / 2);
 
-    const canvasX = offsetX;
-    const canvasY = offsetY;
-    const ray = worldviewContext.raycast(canvasX, canvasY);
+    let x = offsetX;
+    let y = offsetY;
+    let hitboxWidth = 1;
+    let hitboxHeight = 1;
+
+    if (options.readHitmapBox && this._dragStartPos) {
+      const { _dragStartPos } = this;
+      const normalizedDragStartX = clamp(((_dragStartPos.x - (right - width)) / width) * 2 - 1, -1, 1);
+      const normalizedDragStartY = clamp(-(((_dragStartPos.y - (bottom - height)) / height) * 2) + 1, -1, 1);
+      const dragStartOffsetX = Math.floor(((normalizedDragStartX + 1) * clientWidth) / 2);
+      const dragStartOffsetY = Math.floor(((-normalizedDragStartY + 1) * clientHeight) / 2);
+      const deltaX = offsetX - dragStartOffsetX;
+      const deltaY = offsetY - dragStartOffsetY;
+
+      x = deltaX > 0 ? offsetX - deltaX : offsetX;
+      y = deltaY > 0 ? offsetY : offsetY - deltaY;
+      hitboxWidth = Math.abs(deltaX);
+      hitboxHeight = Math.abs(deltaY);
+    }
+
+    const ray = worldviewContext.raycast(x, y);
     if (!ray) {
       return;
     }
@@ -333,7 +289,7 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     // rendering the hitmap on mouse move is expensive, so disable it by default
     if (mouseEventName === "onMouseMove" && !this.props.hitmapOnMouseMove) {
       if (worldviewHandler) {
-        return handleWorldviewMouseInteraction([], ray, e, worldviewHandler);
+        return handleWorldviewMouseInteraction([], ray, e, worldviewHandler, []);
       }
       return;
     }
@@ -341,18 +297,29 @@ export class WorldviewBase extends React.Component<BaseProps, State> {
     // reading hitmap is async so we need to persist the event to use later in the event handler
     (e: any).persist();
     worldviewContext
-      .readHitmap(canvasX, canvasY, !!this.props.enableStackedObjectEvents, this.props.maxStackedObjectCount)
-      .then((mouseEventsWithCommands) => {
+      .readHitmap(
+        x,
+        y,
+        hitboxWidth,
+        hitboxHeight,
+        !!this.props.enableStackedObjectEvents,
+        this.props.maxStackedObjectCount
+      )
+      .then(({ mouseEventsWithCommands, dragEventsWithCommands }) => {
         const mouseEventsByCommand: Map<Command<any>, Array<MouseEventObject>> = aggregate(mouseEventsWithCommands);
+        const dragEventsByCommand: Map<Command<any>, Array<MouseEventObject>> = aggregate(dragEventsWithCommands);
+
         for (const [command, mouseEvents] of mouseEventsByCommand.entries()) {
-          command.handleMouseEvent(mouseEvents, ray, e, mouseEventName);
+          const dragEvents = dragEventsByCommand.get(command);
+          command.handleMouseEvent(mouseEvents, ray, e, mouseEventName, dragEvents);
           if (e.isPropagationStopped()) {
             break;
           }
         }
         if (worldviewHandler && !e.isPropagationStopped()) {
           const mouseEvents = mouseEventsWithCommands.map(([mouseEventObject]) => mouseEventObject);
-          handleWorldviewMouseInteraction(mouseEvents, ray, e, worldviewHandler);
+          const dragEvents = dragEventsWithCommands.map(([dragEventObject]) => dragEventObject);
+          handleWorldviewMouseInteraction(mouseEvents, ray, e, worldviewHandler, dragEvents);
         }
       })
       .catch((e) => {

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -257,7 +257,7 @@ export class WorldviewContext {
         let currentObjectId = 0;
         const excludedObjects = [];
         const mouseEventsWithCommands = [];
-        const dragEventsWithCommands = [];
+        let dragEventsWithCommands = [];
         let counter = 0;
 
         camera.draw(this.cameraStore.state, () => {
@@ -357,6 +357,10 @@ export class WorldviewContext {
                 }
               }
             });
+          } else {
+            // hitboxObject should always be an extension of the single-pixel hit objects
+            // and thus should always contained at least the objects in single-pixel hit
+            dragEventsWithCommands = mouseEventsWithCommands;
           }
 
           resolve({

--- a/packages/regl-worldview/src/WorldviewContext.js
+++ b/packages/regl-worldview/src/WorldviewContext.js
@@ -223,12 +223,14 @@ export class WorldviewContext {
 
   _debouncedPaint = debounce(this.paint, 10);
 
-  readHitmapBox(
+  readHitmap(
     canvasX: number,
     canvasY: number,
-    hitboxWidth: number = 1,
-    hitboxHeight: number = 1
-  ): Promise<Array<[MouseEventObject, Command]>> {
+    hitboxWidth: number,
+    hitboxHeight: number,
+    enableStackedObjectEvents: boolean,
+    maxStackedObjectCount: number
+  ): Promise<Array<[MouseEventObject, Command<any>]>> {
     if (!this.initializedData) {
       return new Promise((_, reject) => reject(new Error("regl data not initialized yet")));
     }
@@ -252,72 +254,10 @@ export class WorldviewContext {
       regl({ framebuffer: _fbo })(() => {
         // clear the framebuffer
         regl.clear({ color: intToRGB(0), depth: 1 });
-        // const currentObjectId = 0;
-        const excludedObjects = [];
-        const mouseEventsWithCommands = [];
-
-        camera.draw(this.cameraStore.state, () => {
-          regl.clear({ color: intToRGB(0), depth: 1 });
-          this._drawInput(true, excludedObjects);
-
-          // make sure the hitbox dimension never exceed the regl framebuffer dimension
-          const w = clamp(hitboxWidth, 1, width - x);
-          const h = clamp(hitboxHeight, 1, height - y);
-
-          const pixels = regl.read({
-            x,
-            y,
-            width: w,
-            height: h,
-          });
-          const hitIds = getIdsFromPixels(pixels);
-
-          hitIds.forEach((currentObjectId) => {
-            const mouseEventObject = this._hitmapObjectIdManager.getObjectByObjectHitmapId(currentObjectId);
-            if (currentObjectId > 0 && mouseEventObject.object) {
-              const command = this._hitmapObjectIdManager.getCommandForObject(mouseEventObject.object);
-              excludedObjects.push(mouseEventObject);
-              if (command) {
-                mouseEventsWithCommands.push([mouseEventObject, command]);
-              }
-            }
-          });
-
-          resolve(mouseEventsWithCommands);
-        });
-      });
-    });
-  }
-
-  readHitmap(
-    canvasX: number,
-    canvasY: number,
-    enableStackedObjectEvents: boolean,
-    maxStackedObjectCount: number
-  ): Promise<Array<[MouseEventObject, Command<any>]>> {
-    if (!this.initializedData) {
-      return new Promise((_, reject) => reject(new Error("regl data not initialized yet")));
-    }
-
-    const { regl, camera, _fbo } = this.initializedData;
-    const { width, height } = this.dimension;
-
-    const x = canvasX;
-    // 0,0 corresponds to the bottom left in the webgl context, but the top left in window coordinates
-    const y = height - canvasY;
-
-    // regl will only resize the framebuffer if the size changed
-    // it uses floored whole pixel values
-    _fbo.resize(Math.floor(width), Math.floor(height));
-
-    return new Promise((resolve) => {
-      // tell regl to use a framebuffer for this render
-      regl({ framebuffer: _fbo })(() => {
-        // clear the framebuffer
-        regl.clear({ color: intToRGB(0), depth: 1 });
         let currentObjectId = 0;
         const excludedObjects = [];
         const mouseEventsWithCommands = [];
+        const dragEventsWithCommands = [];
         let counter = 0;
 
         camera.draw(this.cameraStore.state, () => {
@@ -391,7 +331,38 @@ export class WorldviewContext {
             // eslint-disable-next-line no-unmodified-loop-condition
           } while (currentObjectId !== 0 && enableStackedObjectEvents);
 
-          resolve(mouseEventsWithCommands);
+          if (hitboxWidth > 1 || hitboxHeight > 1) {
+            regl.clear({ color: intToRGB(0), depth: 1 });
+            this._drawInput(true, excludedObjects);
+
+            // make sure the hitbox dimension never exceed the regl framebuffer dimension
+            const w = clamp(hitboxWidth, 1, width - x);
+            const h = clamp(hitboxHeight, 1, height - y);
+
+            const pixels = regl.read({
+              x,
+              y,
+              width: w,
+              height: h,
+            });
+            const hitIds = getIdsFromPixels(pixels);
+
+            hitIds.forEach((currentObjectId) => {
+              const mouseEventObject = this._hitmapObjectIdManager.getObjectByObjectHitmapId(currentObjectId);
+              if (currentObjectId > 0 && mouseEventObject.object) {
+                const command = this._hitmapObjectIdManager.getCommandForObject(mouseEventObject.object);
+                excludedObjects.push(mouseEventObject);
+                if (command) {
+                  dragEventsWithCommands.push([mouseEventObject, command]);
+                }
+              }
+            });
+          }
+
+          resolve({
+            mouseEventsWithCommands,
+            dragEventsWithCommands,
+          });
         });
       });
     });

--- a/packages/regl-worldview/src/commands/Command.js
+++ b/packages/regl-worldview/src/commands/Command.js
@@ -110,13 +110,14 @@ export default class Command<T> extends React.Component<Props<T>> {
     objects: MouseEventObject[],
     ray: Ray,
     e: SyntheticMouseEvent<HTMLCanvasElement>,
-    mouseEventName: MouseEventEnum
+    mouseEventName: MouseEventEnum,
+    hitboxObjects: MouseEventObject[]
   ) {
     const mouseHandler = this.props[mouseEventName];
     if (!mouseHandler || !objects.length) {
       return;
     }
-    mouseHandler(e, { ray, objects });
+    mouseHandler(e, { ray, objects, hitboxObjects });
   }
 
   render() {


### PR DESCRIPTION
- Introduce a new prop called `readHitmapBoxOnDrag` to allow users to opt-in or out of reading the hitmapbox on mouse drag interactions
- Separate the hit objects of single-click hit (`objects`) and the drag box hit (`hitboxObjects`). When not dragging or when `readHitmapBoxOnDrag` is disabled, drag box hit will contain the same objects as the single-click hit